### PR TITLE
Improved interface display on tablets and mobile devices

### DIFF
--- a/app/components/Basic/Footer.tsx
+++ b/app/components/Basic/Footer.tsx
@@ -31,7 +31,7 @@ const socialMedias = [
 
 export function Footer() {
   return (
-    <div className="max-w-view w-full mx-auto pt-20 px-4 md:pt-12 pb-20 md:pb-6 text-primary">
+    <div className="max-w-view w-full mx-auto pt-20 px-4 md:pt-12 pb-20 lg:pb-6 text-primary">
       <PcFooter />
       <MobileFooter />
     </div>

--- a/app/components/Basic/Footer.tsx
+++ b/app/components/Basic/Footer.tsx
@@ -31,7 +31,7 @@ const socialMedias = [
 
 export function Footer() {
   return (
-    <div className="max-w-view w-full mx-auto pt-20 px-4 md:pt-12 pb-14 md:pb-6 text-primary">
+    <div className="max-w-view w-full mx-auto pt-20 px-4 md:pt-12 pb-20 md:pb-6 text-primary">
       <PcFooter />
       <MobileFooter />
     </div>

--- a/app/components/Basic/Header.tsx
+++ b/app/components/Basic/Header.tsx
@@ -236,7 +236,7 @@ export function Header() {
                 {menu.map((menuItem, menuIndex) => (
                   <Link
                     className={cn(
-                      "flex items-center w-full md:w-fit !sonic-title3 text-primary transition-colors h-16"
+                      "flex items-center w-full md:w-fit !sonic-title3 text-primary transition-colors h-16 hover:underline"
                     )}
                     href={menuItem.getLink(networkId)}
                     key={menuIndex}

--- a/app/components/Basic/Header.tsx
+++ b/app/components/Basic/Header.tsx
@@ -182,9 +182,9 @@ export function Header() {
   return (
     <div className="bg-black w-full sticky sticky:backdrop-blur-[35px] top-0 z-30">
       <nav className="flex mx-auto flex-col w-full">
-        <div className="h-16 md:h-20 flex items-center justify-between p-4 md:px-10 md:py-4 bg-black w-full transition-all duration-300">
+        <div className="h-16 lg:h-20 flex items-center justify-between p-4 lg:px-10 lg:py-4 bg-black w-full transition-all duration-300">
           {/* left */}
-          <div className="flex items-center gap-3 md:gap-8">
+          <div className="flex items-center gap-3 lg:gap-8">
             {/* logo */}
             <Link href="/" className="inline-flex flex-row items-center gap-2">
               <img
@@ -192,14 +192,14 @@ export function Header() {
                 className="size-8 min-w-8"
                 src="/sonic.png"
               />
-              <span className="hidden md:inline text-white text-[22px] font-bold font-orbitron tracking-widest">
+              <span className="hidden lg:inline text-white text-[22px] font-bold font-orbitron tracking-widest">
                 SONIC
               </span>
             </Link>
 
             {/* menu */}
             <span
-              className="size-8 inline-flex md:hidden cursor-pointer"
+              className="size-8 inline-flex lg:hidden cursor-pointer"
               onClick={() => setShowMenu(true)}
             >
               <IconMenu color="white" />
@@ -208,13 +208,13 @@ export function Header() {
             {/* nav */}
             <div
               className={cn(
-                "flex flex-col md:flex-row md:gap-8 bg-black fixed items-center md:static inset-0 m-auto z-30 size-full md:w-auto md:h-auto duration-300 transition-transform",
+                "flex flex-col lg:flex-row lg:gap-8 bg-black fixed items-center lg:static inset-0 m-auto z-30 size-full lg:w-auto lg:h-auto duration-300 transition-transform",
                 showMenu
                   ? "translate-x-0"
-                  : "-translate-x-full md:translate-x-0"
+                  : "-translate-x-full lg:translate-x-0"
               )}
             >
-              <div className="w-full flex md:hidden p-4 justify-between items-center">
+              <div className="w-full flex lg:hidden p-4 justify-between items-center">
                 <span className="font-orbitron sonic-title2 text-tertary">
                   Menu
                 </span>
@@ -230,13 +230,13 @@ export function Header() {
               <NetworkSwitch />
 
               {/* spliter */}
-              <div className="w-px h-4 bg-white/20 hidden md:block"></div>
+              <div className="w-px h-4 bg-white/20 hidden lg:block"></div>
 
-              <div className="w-full px-4 md:px-0 md:w-auto flex flex-col md:flex-row items-start md:items-center gap-0 md:gap-8 font-orbitron">
+              <div className="w-full px-4 lg:px-0 lg:w-auto flex flex-col lg:flex-row items-start lg:items-center gap-0 lg:gap-8 font-orbitron">
                 {menu.map((menuItem, menuIndex) => (
                   <Link
                     className={cn(
-                      "flex items-center w-full md:w-fit !sonic-title3 text-primary transition-colors h-16 hover:underline"
+                      "flex items-center w-full lg:w-fit !sonic-title3 text-primary transition-colors h-16 hover:underline"
                     )}
                     href={menuItem.getLink(networkId)}
                     key={menuIndex}
@@ -251,7 +251,7 @@ export function Header() {
           </div>
 
           {/* right */}
-          <div className="gap-6 md:gap-10 flex items-center">
+          <div className="gap-6 lg:gap-10 flex items-center">
             {publicKey && token ? <RingPopover /> : null}
 
             {publicKey && token ? <Notification /> : null}
@@ -265,7 +265,7 @@ export function Header() {
                     : "hover:bg-[#0000FF]/80 active:bg-[#0000FF]/60 cursor-pointer"
                 )}
                 variant={"primary"}
-                size={isMobile ? "sm" : "md"}
+                size={isMobile ? "sm" : "lg"}
                 onClick={handleClickOpenWallet}
               >
                 {connecting ? "Connecting..." : "Connect Wallet"}

--- a/app/components/Basic/NetworkSwitch.tsx
+++ b/app/components/Basic/NetworkSwitch.tsx
@@ -26,7 +26,7 @@ export function NetworkSwitch() {
   return (
     <>
       <Popover open={isOpen} onOpenChange={toggleOpen}>
-        <PopoverTrigger className="h-16 w-full md:w-fit px-4 md:px-0 border-b md:border-b-0 border-line group/network">
+        <PopoverTrigger className="h-16 w-full lg:w-fit px-4 lg:px-0 border-b lg:border-b-0 border-line group/network">
           <div className="flex items-center gap-1">
             <div className="flex-center size-5 relative">
               <span className="animate-[ping_2s_cubic-bezier(0,0,0.2,1)_infinite] absolute inline-flex size-2 rounded-full bg-link opacity-75"></span>
@@ -37,12 +37,12 @@ export function NetworkSwitch() {
             </h3>
             <SwitchNetworkIcon
               className={cn(
-                "size-5 text-icon ml-auto md:ml-1 group-hover/network:text-primary transition-colors group-aria-expanded/network:text-primary"
+                "size-5 text-icon ml-auto lg:ml-1 group-hover/network:text-primary transition-colors group-aria-expanded/network:text-primary"
               )}
             />
           </div>
         </PopoverTrigger>
-        <PopoverContent className="p-0 text-primary w-full md:w-fit border-none outline-none mt-1 hidden md:block">
+        <PopoverContent className="p-0 text-primary w-full lg:w-fit border-none outline-none mt-1 hidden lg:block">
           <div className="py-1 sonic-title3 bg-bg-popup flex-col font-orbitron">
             {networks.map((network: any, networkIndex: number) => (
               <div
@@ -61,7 +61,7 @@ export function NetworkSwitch() {
       </Popover>
       <div
         className={cn(
-          "fixed bottom-0 left-0 w-full pb-4 sonic-title2 bg-bg-popup text-primary flex-col font-orbitron md:hidden transform transition-transform duration-300 ease-in-out",
+          "fixed bottom-0 left-0 w-full pb-4 sonic-title2 bg-bg-popup text-primary flex-col font-orbitron lg:hidden transform transition-transform duration-300 ease-in-out",
           isOpen ? "translate-y-0" : "translate-y-full"
         )}
       >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -127,7 +127,7 @@ export default function Home() {
       )}
 
       <div className="max-w-view px-4 w-full mx-auto flex flex-col justify-center items-center gap-6 grow">
-        <div className="flex gap-3 md:gap-4 justify-center items-center mt-auto md:mt-0">
+        <div className="flex flex-wrap gap-3 md:gap-4 justify-center items-center mt-auto md:mt-0">
           <img
             className="h-11 md:h-[68px] md:w-auto object-contain"
             src="/images/odyssey.png"

--- a/app/task/components/Banner.tsx
+++ b/app/task/components/Banner.tsx
@@ -28,10 +28,10 @@ export default function Banner() {
 
   return (
     <div className="w-full bg-black relative">
-      <div className="text-primary max-w-view w-full mx-auto px-4 h-[164px] md:h-[300px] flex flex-col md:flex-row justify-center md:justify-start md:items-center relative z-10">
+      <div className="text-primary max-w-view w-full mx-auto px-4 h-[164px] lg:h-[300px] flex flex-col lg:flex-row justify-center lg:justify-start lg:items-center relative z-10">
         {/* left part */}
-        <div className="flex flex-col gap-1.5 md:gap-4 max-w-[486px]">
-          <div className="font-orbitron sonic-headline5 md:sonic-headline3">
+        <div className="flex flex-col gap-1.5 lg:gap-4 max-w-[486px]">
+          <div className="font-orbitron sonic-headline5 lg:sonic-headline3">
             Odyssey Task Center
           </div>
           <p className="sonic-body3 text-primary">
@@ -65,31 +65,31 @@ export default function Banner() {
           {/* pc how to play button */}
           <Button
             onClick={handleOnClick}
-            className="sonic-title3 font-orbitron mt-4 px-6 w-fit hidden md:block"
+            className="sonic-title3 font-orbitron mt-4 px-6 w-fit hidden lg:block"
             variant={"outline"}
           >
             {isFrontierV1 ? "How to Play?" : "Season 2 Guides"}
           </Button>
         </div>
         {/* pc carousel */}
-        <div className="h-full grow hidden md:flex justify-end items-center">
+        <div className="h-full grow hidden lg:flex justify-end items-center">
           <Slider setBgClassName={setBgClassName} />
         </div>
       </div>
       {/* mobile carousel */}
-      <div className={cn("flex w-full relative z-20 md:hidden")}>
+      <div className={cn("flex w-full relative z-20 lg:hidden")}>
         <Slider setBgClassName={setBgClassName} />
       </div>
       {/* banner background */}
       <div
         className={cn(
-          "h-[164px] md:h-full absolute top-0 right-0 md:max-w-[63%] w-full z-0",
+          "h-[164px] lg:h-full absolute top-0 right-0 md:max-w-[63%] w-full z-0",
           bgClassName
         )}
       />
 
       {/* mobile how to play button */}
-      <div className="fixed bottom-0 left-0 w-full p-4 z-20 bg-black md:hidden">
+      <div className="fixed bottom-0 left-0 w-full p-4 z-20 bg-black lg:hidden">
         <Button
           onClick={handleOnClick}
           className="sonic-title3 font-orbitron px-6 w-full"

--- a/app/task/components/Slider.tsx
+++ b/app/task/components/Slider.tsx
@@ -100,7 +100,7 @@ export default function Slider({
         })
       ]}
       className={cn(
-        "md:flex md:justify-end md:max-w-[558px] md:w-full rounded md:mb-0",
+        "lg:flex lg:justify-end lg:max-w-[558px] lg:w-full rounded lg:mb-0",
         slides.length > 1 ? "mb-16" : "mb-10"
       )}
     >


### PR DESCRIPTION
[Added hover underline effect to menu items for better user experience](https://github.com/mirrorworld-universe/odyssey-campaign/commit/ccbf2ead309d92d9bb16ac9c373f8b50057d325a)

**BEFORE and AFTER**

https://github.com/user-attachments/assets/a43c34ab-6f48-4188-8d1a-764ffc08c13b


[improved text rendering on mobile devices for better readability](https://github.com/mirrorworld-universe/odyssey-campaign/commit/c464959e28eafe04b491c6ae60cdd71a2d983c3a)

**BEFORE:**

https://github.com/user-attachments/assets/8326722b-6e95-42e7-aee7-c3cce24fbd2d

**AFTER:**

https://github.com/user-attachments/assets/ebe9991b-f246-4ffb-849f-07c2ca4e98c3

[Added pb-20 padding to the footer block to ensure footer visibility o…](https://github.com/mirrorworld-universe/odyssey-campaign/commit/c218bfe76d7e60dd6edfecc5af0ea145808b7d27)

**BEFORE:**

https://github.com/user-attachments/assets/915c9be5-0e26-4a3e-925e-9be4bf21a2e2

**AFTER:**

https://github.com/user-attachments/assets/e0b1f172-1f6c-4d2d-9ef6-a4dc684146fb

[Changed breakpoint from md to lg for better menu display on tablets](https://github.com/mirrorworld-universe/odyssey-campaign/commit/9f0c04e0eade3820340343306b33b682593b40d8)

**BEFORE:**

https://github.com/user-attachments/assets/647b3b57-d62f-4cfb-8961-4453bc0c33fc

**AFTER:**

https://github.com/user-attachments/assets/dfdc4ace-5d68-4154-abd3-ebff0d1c15bc

[Changed breakpoint from md to lg for better banner display on tablets](https://github.com/mirrorworld-universe/odyssey-campaign/commit/e29fe47afa1bb99b4b5552c57b3eb72ae046faa7)

**BEFORE:**

https://github.com/user-attachments/assets/06485220-740b-4159-8471-694d4089c8fa

**AFTER:**

https://github.com/user-attachments/assets/950b69df-c319-4b3d-95d4-c6453a258e2b


